### PR TITLE
Upgrade alchemist-swingui from 9.3.0-devej+a0050f05c to 9.3.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -10,7 +10,6 @@ version.it.unibo.alchemist..alchemist=9.3.0-devej+a0050f05c
 version.it.unibo.alchemist..alchemist-incarnation-protelis=9.3.0-devej+a0050f05c
 ##                                             # available=9.3.0
 
-version.it.unibo.alchemist..alchemist-swingui=9.3.0-devej+a0050f05c
-##                                # available=9.3.0
+version.it.unibo.alchemist..alchemist-swingui=9.3.0
 
 version.kotlintest=3.4.2


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.