### PR TITLE
Upgrade kotest from 4.4.1 to 4.4.2

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -7,6 +7,6 @@
 
 version.it.unibo.alchemist=10.0.1
 
-version.kotest=4.4.1
+version.kotest=4.4.2
 
 version.kotlin=1.4.31


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.