### PR TITLE
Upgrade kotlin from 1.4.32 to 1.5.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -9,4 +9,4 @@ version.it.unibo.alchemist=10.0.1
 
 version.kotest=4.4.3
 
-version.kotlin=1.4.32
+version.kotlin=1.5.0


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.