### PR TITLE
Upgrade kotest from 4.4.3 to 4.5.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -7,6 +7,6 @@
 
 version.it.unibo.alchemist=11.0.0
 
-version.kotest=4.4.3
+version.kotest=4.5.0
 
 version.kotlin=1.5.0


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.