### PR TITLE
Upgrade kotest from 4.6.1 to 4.6.2

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -7,7 +7,7 @@
 
 version.it.unibo.alchemist=11.3.1
 
-version.kotest=4.6.1
+version.kotest=4.6.2
 
 version.kotlin=1.5.30
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.